### PR TITLE
Show only the last 100 txs in bridge history

### DIFF
--- a/packages/widget-react/src/pages/bridge/BridgeHistory.tsx
+++ b/packages/widget-react/src/pages/bridge/BridgeHistory.tsx
@@ -4,7 +4,7 @@ import Page from "@/components/Page"
 import Status from "@/components/Status"
 import AsyncBoundary from "@/components/AsyncBoundary"
 import CheckboxButton from "@/components/CheckboxButton"
-import { useBridgeHistoryList } from "./data/history"
+import { BRIDGE_HISTORY_LIMIT, useBridgeHistoryList } from "./data/history"
 import BridgeHistoryItem from "./BridgeHistoryItem"
 import styles from "./BridgeHistory.module.css"
 
@@ -47,6 +47,13 @@ const BridgeHistory = () => {
               </AsyncBoundary>
             </div>
           ))
+        )}
+
+        {filteredHistory.length >= BRIDGE_HISTORY_LIMIT && (
+          <Status>
+            Only the latest {BRIDGE_HISTORY_LIMIT} items are stored. Older entries will be removed
+            automatically.
+          </Status>
         )}
       </div>
     </Page>

--- a/packages/widget-react/src/pages/bridge/BridgeHistory.tsx
+++ b/packages/widget-react/src/pages/bridge/BridgeHistory.tsx
@@ -49,7 +49,7 @@ const BridgeHistory = () => {
           ))
         )}
 
-        {filteredHistory.length >= BRIDGE_HISTORY_LIMIT && (
+        {history.length >= BRIDGE_HISTORY_LIMIT && (
           <Status>
             Only the latest {BRIDGE_HISTORY_LIMIT} items are stored. Older entries will be removed
             automatically.

--- a/packages/widget-react/src/pages/bridge/data/history.ts
+++ b/packages/widget-react/src/pages/bridge/data/history.ts
@@ -29,7 +29,9 @@ export function useBridgeHistoryList() {
     (tx: TxIdentifier, details: HistoryDetails) => {
       localStorage.setItem(detailKeyOf(tx), JSON.stringify(details))
       setList((prev = []) => {
-        prev.slice(BRIDGE_HISTORY_LIMIT - 1).map((tx) => localStorage.removeItem(detailKeyOf(tx))) // Remove old items from localStorage
+        prev
+          .slice(BRIDGE_HISTORY_LIMIT - 1)
+          .forEach((tx) => localStorage.removeItem(detailKeyOf(tx))) // Remove old items from localStorage
         return [tx, ...prev.slice(0, BRIDGE_HISTORY_LIMIT - 1)] // Keep only the last 100 items
       })
     },

--- a/packages/widget-react/src/pages/bridge/data/history.ts
+++ b/packages/widget-react/src/pages/bridge/data/history.ts
@@ -28,11 +28,15 @@ export function useBridgeHistoryList() {
   const addHistoryItem = useCallback(
     (tx: TxIdentifier, details: HistoryDetails) => {
       localStorage.setItem(detailKeyOf(tx), JSON.stringify(details))
-      // Remove old txs from localStorage
-      list.slice(BRIDGE_HISTORY_LIMIT - 1).forEach((tx) => localStorage.removeItem(detailKeyOf(tx)))
-      setList((prev = []) => [tx, ...prev.slice(0, BRIDGE_HISTORY_LIMIT - 1)]) // Keep only the last 100 txs
+
+      // Remove the oldest item if we exceed the limit
+      for (const item of list.slice(BRIDGE_HISTORY_LIMIT - 1)) {
+        localStorage.removeItem(detailKeyOf(item))
+      }
+
+      setList((prev = []) => [tx, ...prev.slice(0, BRIDGE_HISTORY_LIMIT - 1)])
     },
-    [setList, list],
+    [list, setList],
   )
 
   const getHistoryDetails = useCallback((tx: TxIdentifier) => {

--- a/packages/widget-react/src/pages/bridge/data/history.ts
+++ b/packages/widget-react/src/pages/bridge/data/history.ts
@@ -28,14 +28,11 @@ export function useBridgeHistoryList() {
   const addHistoryItem = useCallback(
     (tx: TxIdentifier, details: HistoryDetails) => {
       localStorage.setItem(detailKeyOf(tx), JSON.stringify(details))
-      setList((prev = []) => {
-        prev
-          .slice(BRIDGE_HISTORY_LIMIT - 1)
-          .forEach((tx) => localStorage.removeItem(detailKeyOf(tx))) // Remove old items from localStorage
-        return [tx, ...prev.slice(0, BRIDGE_HISTORY_LIMIT - 1)] // Keep only the last 100 items
-      })
+      // Remove old txs from localStorage
+      list.slice(BRIDGE_HISTORY_LIMIT - 1).forEach((tx) => localStorage.removeItem(detailKeyOf(tx)))
+      setList((prev = []) => [tx, ...prev.slice(0, BRIDGE_HISTORY_LIMIT - 1)]) // Keep only the last 100 txs
     },
-    [setList],
+    [setList, list],
   )
 
   const getHistoryDetails = useCallback((tx: TxIdentifier) => {

--- a/packages/widget-react/src/pages/bridge/data/history.ts
+++ b/packages/widget-react/src/pages/bridge/data/history.ts
@@ -20,13 +20,18 @@ export interface HistoryDetails extends TxIdentifier {
 const detailKeyOf = ({ chainId, txHash }: TxIdentifier) =>
   `${LocalStorageKey.BRIDGE_HISTORY}:${chainId}:${txHash}`
 
+export const BRIDGE_HISTORY_LIMIT = 100
+
 export function useBridgeHistoryList() {
   const [list = [], setList] = useLocalStorage<TxIdentifier[]>(LocalStorageKey.BRIDGE_HISTORY, [])
 
   const addHistoryItem = useCallback(
     (tx: TxIdentifier, details: HistoryDetails) => {
       localStorage.setItem(detailKeyOf(tx), JSON.stringify(details))
-      setList((prev = []) => [tx, ...prev])
+      setList((prev = []) => {
+        prev.slice(BRIDGE_HISTORY_LIMIT - 1).map((tx) => localStorage.removeItem(detailKeyOf(tx))) // Remove old items from localStorage
+        return [tx, ...prev.slice(0, BRIDGE_HISTORY_LIMIT - 1)] // Keep only the last 100 items
+      })
     },
     [setList],
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a visible message informing users that only the latest 100 bridge history items are stored, with older entries automatically removed.

- **Bug Fixes**
  - Improved bridge history management to automatically remove older entries, ensuring only the most recent 100 items are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->