### PR TITLE
Move NFT send button

### DIFF
--- a/packages/widget-react/src/pages/wallet/tabs/nft/NftDetails.tsx
+++ b/packages/widget-react/src/pages/wallet/tabs/nft/NftDetails.tsx
@@ -19,6 +19,10 @@ const NftDetails = () => {
         <h2 className={styles.name}>{name}</h2>
       </header>
 
+      <Footer>
+        <Button.White onClick={() => navigate("/nft/send", state)}>Send</Button.White>
+      </Footer>
+
       {attributes && (
         <div className={styles.attributes}>
           <header className={styles.title}>Traits ({attributes.length})</header>
@@ -33,10 +37,6 @@ const NftDetails = () => {
           </div>
         </div>
       )}
-
-      <Footer>
-        <Button.White onClick={() => navigate("/nft/send", state)}>Send</Button.White>
-      </Footer>
     </Page>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the layout by moving the "Send" button to appear directly below the header section in the NFT details view. The button’s functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->