### PR TITLE
Use mono font for addresses

### DIFF
--- a/packages/widget-react/src/components/form/RecipientInput.module.css
+++ b/packages/widget-react/src/components/form/RecipientInput.module.css
@@ -7,8 +7,8 @@
 .wrapper {
   position: relative;
 
-  input {
-    padding-right: 42px;
+  .input {
+    padding-right: calc(6px + 2 * 10px + 16px);
   }
 
   .clear {

--- a/packages/widget-react/src/components/form/RecipientInput.module.css
+++ b/packages/widget-react/src/components/form/RecipientInput.module.css
@@ -7,6 +7,10 @@
 .wrapper {
   position: relative;
 
+  input {
+    padding-right: 42px;
+  }
+
   .clear {
     position: absolute;
     right: 6px;

--- a/packages/widget-react/src/components/form/RecipientInput.tsx
+++ b/packages/widget-react/src/components/form/RecipientInput.tsx
@@ -77,7 +77,7 @@ const RecipientInput = (props: Props) => {
     }
     if (usernameAddress) {
       return (
-        <InputHelp level="success" className="mono">
+        <InputHelp level="success" className="monospace">
           {usernameAddress}
         </InputHelp>
       )

--- a/packages/widget-react/src/components/form/RecipientInput.tsx
+++ b/packages/widget-react/src/components/form/RecipientInput.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx"
 import type { Ref } from "react"
 import { useState, useEffect } from "react"
 import { mergeRefs } from "react-merge-refs"
@@ -103,7 +104,7 @@ const RecipientInput = (props: Props) => {
       <div className={styles.wrapper}>
         <input
           id="recipient"
-          className={styles.input}
+          className={clsx(styles.input, AddressUtils.isAddress(inputValue) && "monospace")}
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value.trim())}
           placeholder="Address or username"

--- a/packages/widget-react/src/components/form/RecipientInput.tsx
+++ b/packages/widget-react/src/components/form/RecipientInput.tsx
@@ -76,7 +76,11 @@ const RecipientInput = (props: Props) => {
       return <InputHelp level="error">{error.message}</InputHelp>
     }
     if (usernameAddress) {
-      return <InputHelp level="success">{usernameAddress}</InputHelp>
+      return (
+        <InputHelp level="success" className="mono">
+          {usernameAddress}
+        </InputHelp>
+      )
     }
     if (mode === "onSubmit" && inputValue && !resolvedAddress) {
       return <InputHelp level="error">Invalid address</InputHelp>

--- a/packages/widget-react/src/components/form/RecipientInput.tsx
+++ b/packages/widget-react/src/components/form/RecipientInput.tsx
@@ -103,6 +103,7 @@ const RecipientInput = (props: Props) => {
       <div className={styles.wrapper}>
         <input
           id="recipient"
+          className={styles.input}
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value.trim())}
           placeholder="Address or username"

--- a/packages/widget-react/src/pages/bridge/BridgeAccount.tsx
+++ b/packages/widget-react/src/pages/bridge/BridgeAccount.tsx
@@ -63,7 +63,7 @@ const BridgeAccount = ({ type }: Props) => {
         ) : (
           <>
             {connected && <Image src={connected.image} width={18} height={18} />}
-            <span>{truncate(address)}</span>
+            <span className="mono">{truncate(address)}</span>
           </>
         )}
       </ModalTrigger>
@@ -101,7 +101,7 @@ const BridgeAccount = ({ type }: Props) => {
 
         return (
           <div className={styles.account}>
-            <span>{truncate(address)}</span>
+            <span className="mono">{truncate(address)}</span>
             <button
               type="button"
               className={styles.clear}
@@ -117,7 +117,7 @@ const BridgeAccount = ({ type }: Props) => {
       case "cosmos": {
         return renderDstModalTrigger(
           <>
-            <span>{address ? truncate(address) : "Recipient"}</span>
+            <span className="mono">{address ? truncate(address) : "Recipient"}</span>
             <IconEdit size={14} />
           </>,
         )

--- a/packages/widget-react/src/pages/bridge/BridgeAccount.tsx
+++ b/packages/widget-react/src/pages/bridge/BridgeAccount.tsx
@@ -63,7 +63,7 @@ const BridgeAccount = ({ type }: Props) => {
         ) : (
           <>
             {connected && <Image src={connected.image} width={18} height={18} />}
-            <span className="mono">{truncate(address)}</span>
+            <span className="monospace">{truncate(address)}</span>
           </>
         )}
       </ModalTrigger>
@@ -101,7 +101,7 @@ const BridgeAccount = ({ type }: Props) => {
 
         return (
           <div className={styles.account}>
-            <span className="mono">{truncate(address)}</span>
+            <span className="monospace">{truncate(address)}</span>
             <button
               type="button"
               className={styles.clear}
@@ -117,7 +117,7 @@ const BridgeAccount = ({ type }: Props) => {
       case "cosmos": {
         return renderDstModalTrigger(
           <>
-            <span className="mono">{address ? truncate(address) : "Recipient"}</span>
+            <span className="monospace">{address ? truncate(address) : "Recipient"}</span>
             <IconEdit size={14} />
           </>,
         )

--- a/packages/widget-react/src/pages/bridge/BridgeAccount.tsx
+++ b/packages/widget-react/src/pages/bridge/BridgeAccount.tsx
@@ -117,7 +117,11 @@ const BridgeAccount = ({ type }: Props) => {
       case "cosmos": {
         return renderDstModalTrigger(
           <>
-            <span className="monospace">{address ? truncate(address) : "Recipient"}</span>
+            {address ? (
+              <span className="monospace">{truncate(address)}</span>
+            ) : (
+              <span>Recipient</span>
+            )}
             <IconEdit size={14} />
           </>,
         )

--- a/packages/widget-react/src/pages/bridge/BridgeHistoryItem.tsx
+++ b/packages/widget-react/src/pages/bridge/BridgeHistoryItem.tsx
@@ -98,7 +98,7 @@ const BridgeHistoryItem = ({ tx }: { tx: TxIdentifier }) => {
             <span>{symbol}</span>
           </div>
           <div className={styles.chain}>
-            on {pretty_name || chain_name} ({truncate(address)})
+            on {pretty_name || chain_name} <span className="mono">({truncate(address)})</span>
           </div>
         </div>
       </div>

--- a/packages/widget-react/src/pages/bridge/BridgeHistoryItem.tsx
+++ b/packages/widget-react/src/pages/bridge/BridgeHistoryItem.tsx
@@ -98,7 +98,7 @@ const BridgeHistoryItem = ({ tx }: { tx: TxIdentifier }) => {
             <span>{symbol}</span>
           </div>
           <div className={styles.chain}>
-            on {pretty_name || chain_name} <span className="mono">({truncate(address)})</span>
+            on {pretty_name || chain_name} <span className="monospace">({truncate(address)})</span>
           </div>
         </div>
       </div>

--- a/packages/widget-react/src/pages/bridge/OperationItem.tsx
+++ b/packages/widget-react/src/pages/bridge/OperationItem.tsx
@@ -56,7 +56,7 @@ const OperationItemComponent = (props: ComponentProps) => {
                 {({ copy, copied }) => (
                   <button className={styles.address} onClick={copy}>
                     {walletIcon}
-                    <span className="mono">{copied ? "Copied!" : truncate(address)}</span>
+                    <span className="monospace">{copied ? "Copied!" : truncate(address)}</span>
                   </button>
                 )}
               </CopyButton>

--- a/packages/widget-react/src/pages/bridge/OperationItem.tsx
+++ b/packages/widget-react/src/pages/bridge/OperationItem.tsx
@@ -56,7 +56,7 @@ const OperationItemComponent = (props: ComponentProps) => {
                 {({ copy, copied }) => (
                   <button className={styles.address} onClick={copy}>
                     {walletIcon}
-                    <span>{copied ? "Copied!" : truncate(address)}</span>
+                    <span className="mono">{copied ? "Copied!" : truncate(address)}</span>
                   </button>
                 )}
               </CopyButton>

--- a/packages/widget-react/src/pages/bridge/OperationItem.tsx
+++ b/packages/widget-react/src/pages/bridge/OperationItem.tsx
@@ -56,7 +56,11 @@ const OperationItemComponent = (props: ComponentProps) => {
                 {({ copy, copied }) => (
                   <button className={styles.address} onClick={copy}>
                     {walletIcon}
-                    <span className="monospace">{copied ? "Copied!" : truncate(address)}</span>
+                    {copied ? (
+                      <span>Copied!</span>
+                    ) : (
+                      <span className="monospace">{truncate(address)}</span>
+                    )}
                   </button>
                 )}
               </CopyButton>

--- a/packages/widget-react/src/public/utils/address.ts
+++ b/packages/widget-react/src/public/utils/address.ts
@@ -1,4 +1,4 @@
-import { getAddress } from "ethers"
+import { getAddress, isAddress } from "ethers"
 import { fromBech32, fromHex, toBech32, toHex } from "@cosmjs/encoding"
 
 export const AddressUtils = {
@@ -33,6 +33,19 @@ export const AddressUtils = {
     const isSpecial = bytes.subarray(0, bytes.length - 1).every((byte) => byte === 0) && last < 0x10
     if (isSpecial) return checksummed.replace(/^0x0+/, "0x")
     return checksummed
+  },
+
+  isAddress(address: string) {
+    if (isAddress(address)) {
+      return true
+    }
+
+    try {
+      fromBech32(address)
+      return true
+    } catch {
+      return false
+    }
   },
 
   validate(address: string, prefix: string = "init") {

--- a/packages/widget-react/src/styles/global.css
+++ b/packages/widget-react/src/styles/global.css
@@ -142,6 +142,6 @@
   color: var(--info);
 }
 
-:where(.mono) {
+:where(.monospace) {
   font-family: var(--monospace);
 }

--- a/packages/widget-react/src/styles/global.css
+++ b/packages/widget-react/src/styles/global.css
@@ -141,3 +141,7 @@
 :where(.info) {
   color: var(--info);
 }
+
+:where(.mono) {
+  font-family: var(--monospace);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Improved readability of addresses by applying a consistent monospace font style to address displays across various components.
	- Increased right padding for input fields to better align UI elements.
- **Bug Fixes**
	- Enhanced visual clarity for success messages and copied address confirmations by updating their styling.
- **New Features**
	- Added unified address validation supporting both Ethereum and Bech32 formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->