### PR TITLE
Fix signer issue on account change

### DIFF
--- a/packages/widget-react/src/data/signer.ts
+++ b/packages/widget-react/src/data/signer.ts
@@ -75,27 +75,6 @@ export class OfflineSigner implements OfflineAminoSigner {
     return publicKey
   }
 
-  // Cache the public key requests to avoid duplicated requests for the same address.
-  private static signMessageCache: Record<string, Promise<string>> = {}
-  private async signMessageWithCache(message: string): Promise<string> {
-    const cacheKey = `${this.address}:${message}`
-
-    if (!OfflineSigner.signMessageCache[cacheKey]) console.log("signMessageWithCache", cacheKey)
-
-    const signaturePromise = OfflineSigner.signMessageCache[cacheKey] || this.signMessage(message)
-    // add signature to the cache if needed
-    if (!OfflineSigner.signMessageCache[cacheKey]) {
-      OfflineSigner.signMessageCache[cacheKey] = signaturePromise
-    }
-    // wait for the signature to be resolved
-    try {
-      return await signaturePromise
-    } finally {
-      // delete the cached request after resolving it (allows to retry if the request fails)
-      delete OfflineSigner.signMessageCache[cacheKey]
-    }
-  }
-
   private async getPublicKey() {
     // Recover the public key by having the wallet sign a fixed message once.
     // EIP-191 is supported across wallets and doesn't require a prior key
@@ -103,7 +82,7 @@ export class OfflineSigner implements OfflineAminoSigner {
     // malicious host to derive the user's public key without explicit consent.
     // The key itself is not sensitive.
     const message = "Sign this message to identify your Initia account."
-    const signature = await this.signMessageWithCache(message)
+    const signature = await this.signMessage(message)
     const messageHash = ethers.hashMessage(message)
     const uncompressedPublicKey = ethers.SigningKey.recoverPublicKey(messageHash, signature)
     return Secp256k1.compressPubkey(fromHex(uncompressedPublicKey.replace("0x", "")))


### PR DESCRIPTION
- update client cache to index current address, not only chain id
- cache pubkey signature requests to prevent multiple requests to the wallet when multiple OfflineSigners are used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved signing performance by introducing caching for repeated signing requests with the same message and address.
- **Bug Fixes**
  - Enhanced client caching to ensure correct behavior when switching between different user addresses and chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->