### PR TITLE
Use Glyph for NFTs images

### DIFF
--- a/packages/widget-react/src/components/Image.tsx
+++ b/packages/widget-react/src/components/Image.tsx
@@ -18,7 +18,7 @@ const Image = ({ src, alt, placeholder, classNames, circle, ...attrs }: Props) =
     <Img
       {...attrs}
       className={clsx(attrs.className, { [styles.circle]: circle })}
-      src={getProxyImage(src)}
+      src={src || ""}
       alt={alt}
       unloader={unloader}
       loading="lazy"
@@ -27,10 +27,3 @@ const Image = ({ src, alt, placeholder, classNames, circle, ...attrs }: Props) =
 }
 
 export default Image
-
-function getProxyImage(url?: string) {
-  if (!url) return ""
-  if (url.trim().startsWith("data:image/")) return url
-  const proxy = "https://img.initia.xyz/?url="
-  return proxy + url.replace(proxy, "")
-}

--- a/packages/widget-react/src/components/Image.tsx
+++ b/packages/widget-react/src/components/Image.tsx
@@ -14,11 +14,16 @@ const Image = ({ src, alt, placeholder, classNames, circle, ...attrs }: Props) =
   const unloader = placeholder ?? (
     <div className={clsx(styles.placeholder, classNames?.placeholder)} style={{ width, height }} />
   )
+
+  if (!src) {
+    return unloader
+  }
+
   return (
     <Img
       {...attrs}
       className={clsx(attrs.className, { [styles.circle]: circle })}
-      src={src || ""}
+      src={src}
       alt={alt}
       unloader={unloader}
       loading="lazy"

--- a/packages/widget-react/src/data/constants.ts
+++ b/packages/widget-react/src/data/constants.ts
@@ -24,3 +24,5 @@ export const LocalStorageKey = {
   // op
   OP_REMINDER: `${NAMESPACE}:op:reminder`,
 }
+
+export const IMG_ENDPOINT_URL = "https://glyph.initia.xyz"

--- a/packages/widget-react/src/data/constants.ts
+++ b/packages/widget-react/src/data/constants.ts
@@ -24,5 +24,3 @@ export const LocalStorageKey = {
   // op
   OP_REMINDER: `${NAMESPACE}:op:reminder`,
 }
-
-export const IMG_ENDPOINT_URL = "https://glyph.initia.xyz"

--- a/packages/widget-react/src/pages/wallet/tabs/nft/CollectionDetails.tsx
+++ b/packages/widget-react/src/pages/wallet/tabs/nft/CollectionDetails.tsx
@@ -27,7 +27,9 @@ const CollectionDetails = () => {
             {(nft) => (
               <div className={styles.item}>
                 <NftThumbnail
-                  src={nft.image}
+                  chain={chain}
+                  collection={collection}
+                  nft={nft}
                   onClick={() => navigate("/nft", { collection, nft, chain })}
                 />
                 <div className={styles.name}>{nft.name}</div>

--- a/packages/widget-react/src/pages/wallet/tabs/nft/CollectionItem.tsx
+++ b/packages/widget-react/src/pages/wallet/tabs/nft/CollectionItem.tsx
@@ -21,7 +21,7 @@ const CollectionItem = ({ chain, collection }: Props) => {
     <Link className={styles.item} to="/collection" state={{ collection, chain }}>
       {primaryToken && (
         <WithNormalizedNft nftResponse={primaryToken}>
-          {({ image }) => <NftThumbnail src={image} size={58} />}
+          {(nft) => <NftThumbnail chain={chain} collection={collection} nft={nft} size={58} />}
         </WithNormalizedNft>
       )}
 

--- a/packages/widget-react/src/pages/wallet/tabs/nft/NftDetails.tsx
+++ b/packages/widget-react/src/pages/wallet/tabs/nft/NftDetails.tsx
@@ -9,13 +9,13 @@ import styles from "./NftDetails.module.css"
 const NftDetails = () => {
   const navigate = useNavigate()
   const state = useLocationState<ChainCollectionNftCollectionState>()
-  const { collection, nft } = state
+  const { collection, nft, chain } = state
   const { image, name, attributes } = nft
 
   return (
     <Page title={collection.name}>
       <header className={styles.header}>
-        {image && <NftThumbnail src={image} />}
+        {image && <NftThumbnail chain={chain} collection={collection} nft={nft} />}
         <h2 className={styles.name}>{name}</h2>
       </header>
 

--- a/packages/widget-react/src/pages/wallet/tabs/nft/NftThumbnail.tsx
+++ b/packages/widget-react/src/pages/wallet/tabs/nft/NftThumbnail.tsx
@@ -1,14 +1,24 @@
 import clsx from "clsx"
 import Image from "@/components/Image"
+import { IMG_ENDPOINT_URL } from "@/data/constants"
+import type { NormalizedChain } from "@/data/chains"
+import type { NormalizedCollection, NormalizedNft } from "./queries"
 import styles from "./NftThumbnail.module.css"
 
 interface Props {
-  src?: string
+  chain: NormalizedChain
+  collection: NormalizedCollection
+  nft: NormalizedNft
   size?: number
   onClick?: () => void
 }
 
-const NftThumbnail = ({ src, size, onClick }: Props) => {
+const NftThumbnail = ({ chain, collection, nft, size, onClick }: Props) => {
+  const src = new URL(
+    `/v1/${chain.chainId}/${collection.object_addr}/${nft.object_addr || nft.token_id}`,
+    IMG_ENDPOINT_URL,
+  ).toString()
+
   if (onClick) {
     return (
       <button

--- a/packages/widget-react/src/pages/wallet/tabs/nft/NftThumbnail.tsx
+++ b/packages/widget-react/src/pages/wallet/tabs/nft/NftThumbnail.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx"
 import Image from "@/components/Image"
-import { IMG_ENDPOINT_URL } from "@/data/constants"
 import type { NormalizedChain } from "@/data/chains"
 import type { NormalizedCollection, NormalizedNft } from "./queries"
 import styles from "./NftThumbnail.module.css"
@@ -16,7 +15,7 @@ interface Props {
 const NftThumbnail = ({ chain, collection, nft, size, onClick }: Props) => {
   const src = new URL(
     `/v1/${chain.chainId}/${collection.object_addr}/${nft.object_addr || nft.token_id}`,
-    IMG_ENDPOINT_URL,
+    "https://glyph.initia.xyz",
   ).toString()
 
   if (onClick) {

--- a/packages/widget-react/src/pages/wallet/txs/send-nft/SendNftFields.tsx
+++ b/packages/widget-react/src/pages/wallet/txs/send-nft/SendNftFields.tsx
@@ -94,7 +94,7 @@ const SendNftFields = () => {
   return (
     <form onSubmit={handleSubmit(() => mutate())}>
       <header className={styles.header}>
-        {nft.image && <NftThumbnail src={nft.image} size={80} />}
+        {nft.image && <NftThumbnail chain={srcChain} collection={collection} nft={nft} size={80} />}
         <div className={styles.name}>
           <div className={styles.collection}>{collection.name}</div>
           <div className={styles.nft}>{nft.name}</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- NFT thumbnails now display images using a new URL format based on chain, collection, and NFT details, providing more contextual rendering.
- **Refactor**
	- Simplified image handling by removing proxy logic and updating components to pass complete NFT, collection, and chain data instead of just image URLs.
- **Bug Fixes**
	- Improved fallback behavior for missing NFT images, ensuring a placeholder is shown when no image is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->