### PR TITLE
Add tooltip to OP Withdrawal countown

### DIFF
--- a/packages/widget-react/src/pages/bridge/op/ClaimButton.module.css
+++ b/packages/widget-react/src/pages/bridge/op/ClaimButton.module.css
@@ -16,9 +16,6 @@
 .claimed {
   display: flex;
   align-items: center;
-  gap: 8px;
-
-  .icon {
-    color: var(--success);
-  }
+  gap: 4px;
+  color: var(--success);
 }

--- a/packages/widget-react/src/pages/bridge/op/ClaimButton.tsx
+++ b/packages/widget-react/src/pages/bridge/op/ClaimButton.tsx
@@ -70,7 +70,7 @@ const ClaimButton = () => {
     return (
       <div className={styles.claimed}>
         <div className={styles.icon}>
-          <IconCheckCircleFilled size={18} />
+          <IconCheckCircleFilled size={14} />
         </div>
         <span>Success</span>
       </div>

--- a/packages/widget-react/src/pages/bridge/op/ClaimButton.tsx
+++ b/packages/widget-react/src/pages/bridge/op/ClaimButton.tsx
@@ -69,9 +69,7 @@ const ClaimButton = () => {
   if (claimed) {
     return (
       <div className={styles.claimed}>
-        <div className={styles.icon}>
-          <IconCheckCircleFilled size={14} />
-        </div>
+        <IconCheckCircleFilled size={14} />
         <span>Success</span>
       </div>
     )

--- a/packages/widget-react/src/pages/bridge/op/WithdrawalAction.tsx
+++ b/packages/widget-react/src/pages/bridge/op/WithdrawalAction.tsx
@@ -1,10 +1,10 @@
 import { isFuture } from "date-fns"
 import WithIsSubmitted from "./WithIsSubmitted"
 import WithdrawalSubmitted from "./WithdrawalSubmitted"
+import WithdrawalCountdown from "./WithdrawalCountDown"
 import WithClaimableDate from "./WithClaimableDate"
 import WithUpdateReminder from "./WithUpdateReminder"
 import ClaimButton from "./ClaimButton"
-import Countdown from "./Countdown"
 
 const WithdrawalAction = () => {
   return (
@@ -19,7 +19,7 @@ const WithdrawalAction = () => {
                 <WithdrawalSubmitted />
               ) : (
                 <WithUpdateReminder date={date}>
-                  {isFuture(date) ? <Countdown date={date} /> : <ClaimButton />}
+                  {isFuture(date) ? <WithdrawalCountdown date={date} /> : <ClaimButton />}
                 </WithUpdateReminder>
               )
             }

--- a/packages/widget-react/src/pages/bridge/op/WithdrawalCountDown.tsx
+++ b/packages/widget-react/src/pages/bridge/op/WithdrawalCountDown.tsx
@@ -1,13 +1,13 @@
 import { IconInfoFilled } from "@initia/icons-react"
 import WidgetTooltip from "@/components/WidgetTooltip"
-import styles from "./WithdrawalCountdown.module.css"
 import Countdown from "./Countdown"
+import styles from "./WithdrawalCountdown.module.css"
 
-const DESCRIPTION = "This is the time remaining before you can claim your Op withdrawal request."
+const DESCRIPTION = "Time remaining before you can claim"
 
 const WithdrawalCountdown = ({ date }: { date: Date }) => {
   return (
-    <div className={styles.submitted}>
+    <div className={styles.container}>
       <Countdown date={date} />
       <WidgetTooltip label={DESCRIPTION}>
         <span className={styles.icon}>

--- a/packages/widget-react/src/pages/bridge/op/WithdrawalCountDown.tsx
+++ b/packages/widget-react/src/pages/bridge/op/WithdrawalCountDown.tsx
@@ -1,14 +1,14 @@
 import { IconInfoFilled } from "@initia/icons-react"
 import WidgetTooltip from "@/components/WidgetTooltip"
-import styles from "./WithdrawalSubmitted.module.css"
+import styles from "./WithdrawalCountdown.module.css"
+import Countdown from "./Countdown"
 
-const DESCRIPTION =
-  "Your withdrawal request is being processed, and time remaining will show up once it is in queue."
+const DESCRIPTION = "This is the time remaining before you can claim your Op withdrawal request."
 
-const WithdrawalSubmitted = () => {
+const WithdrawalCountdown = ({ date }: { date: Date }) => {
   return (
     <div className={styles.submitted}>
-      <span>Withdrawal submitted</span>
+      <Countdown date={date} />
       <WidgetTooltip label={DESCRIPTION}>
         <span className={styles.icon}>
           <IconInfoFilled size={12} />
@@ -18,4 +18,4 @@ const WithdrawalSubmitted = () => {
   )
 }
 
-export default WithdrawalSubmitted
+export default WithdrawalCountdown

--- a/packages/widget-react/src/pages/bridge/op/WithdrawalCountdown.module.css
+++ b/packages/widget-react/src/pages/bridge/op/WithdrawalCountdown.module.css
@@ -1,0 +1,9 @@
+.submitted {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.icon {
+  color: var(--gray-2);
+}

--- a/packages/widget-react/src/pages/bridge/op/WithdrawalCountdown.module.css
+++ b/packages/widget-react/src/pages/bridge/op/WithdrawalCountdown.module.css
@@ -1,4 +1,4 @@
-.submitted {
+.container {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/packages/widget-react/src/pages/bridge/op/WithdrawalSubmitted.module.css
+++ b/packages/widget-react/src/pages/bridge/op/WithdrawalSubmitted.module.css
@@ -1,4 +1,4 @@
-.submitted {
+.container {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/packages/widget-react/src/pages/bridge/op/WithdrawalSubmitted.tsx
+++ b/packages/widget-react/src/pages/bridge/op/WithdrawalSubmitted.tsx
@@ -7,7 +7,7 @@ const DESCRIPTION =
 
 const WithdrawalSubmitted = () => {
   return (
-    <div className={styles.submitted}>
+    <div className={styles.container}>
       <span>Withdrawal submitted</span>
       <WidgetTooltip label={DESCRIPTION}>
         <span className={styles.icon}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new countdown component with an info tooltip to display the time remaining before an Optimism withdrawal can be claimed.

* **Style**
  * Improved visual styling of claimed status and countdown elements for better clarity and consistency.
  * Adjusted icon sizes and colors for enhanced visual alignment.

* **Bug Fixes**
  * Updated tooltip icons for clearer information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->