### PR TITLE
Show MAX fee warning only for fee tokens

### DIFF
--- a/packages/widget-react/src/pages/bridge/BridgeFields.tsx
+++ b/packages/widget-react/src/pages/bridge/BridgeFields.tsx
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js"
+import { isAddress } from "ethers"
 import { sentenceCase } from "change-case"
 import { useEffect, useMemo, useState } from "react"
 import { useDebounce, useLocalStorage } from "react-use"
@@ -13,6 +14,7 @@ import { useNavigate } from "@/lib/router"
 import { formatAmount, formatNumber, toQuantity } from "@/public/utils"
 import { useModal } from "@/public/app/ModalContext"
 import { LocalStorageKey } from "@/data/constants"
+import { useInitiaRegistry } from "@/data/chains"
 import Button from "@/components/Button"
 import ChainAssetQuantityLayout from "@/components/form/ChainAssetQuantityLayout"
 import BalanceButton from "@/components/form/BalanceButton"
@@ -56,6 +58,7 @@ const BridgeFields = () => {
   const values = watch()
   const { srcChainId, srcDenom, dstChainId, dstDenom, quantity, sender, slippagePercent } = values
 
+  const initiaRegistry = useInitiaRegistry()
   const srcChain = useSkipChain(srcChainId)
   const srcChainType = useChainType(srcChain)
   const dstChain = useSkipChain(dstChainId)
@@ -186,6 +189,15 @@ const BridgeFields = () => {
     BigNumber(quantity).gt(0) &&
     BigNumber(quantity).isEqualTo(toQuantity(srcBalance?.amount, srcBalance?.decimals ?? 0))
 
+  const isFeeToken =
+    srcChain.chain_type === "evm"
+      ? !isAddress(srcDenom)
+      : // check initia registry to handle USDC on L1, which due to dynamic gas price is not included in Skip registry
+        initiaRegistry
+          .find(({ chain_id }) => chain_id === srcChainId)
+          ?.fees.fee_tokens.some(({ denom }) => denom === srcDenom) ||
+        srcChain.fee_assets.some(({ denom }) => denom === srcDenom)
+
   const renderFees = (fees: FeeJson[], tooltip: string) => {
     if (!fees.length) return null
     return (
@@ -265,7 +277,7 @@ const BridgeFields = () => {
                 </FormHelp>
               ))}
               {routeErrorInfo && <FormHelp level="info">{routeErrorInfo}</FormHelp>}
-              {isMaxAmount && (
+              {isMaxAmount && isFeeToken && (
                 <FormHelp level="warning">Make sure to leave enough funds to cover fees</FormHelp>
               )}
               {route?.warning && <FormHelp level="warning">{route.warning.message}</FormHelp>}

--- a/packages/widget-react/src/pages/wallet/txs/send/SendFields.tsx
+++ b/packages/widget-react/src/pages/wallet/txs/send/SendFields.tsx
@@ -36,6 +36,8 @@ export const SendFields = () => {
   const balance = balances.find((coin) => coin.denom === denom)?.amount ?? "0"
   const price = prices?.find(({ id }) => id === denom)?.price
 
+  const isFeeToken = chain.fees.fee_tokens.some((token) => token.denom === denom)
+
   const { mutate, isPending } = useMutation({
     mutationFn: ({ chainId, denom, quantity, recipient, memo }: FormValues) => {
       const amount = toAmount(quantity, decimals)
@@ -92,7 +94,8 @@ export const SendFields = () => {
 
           <FormHelp.Stack>
             {BigNumber(quantity).gt(0) &&
-              BigNumber(quantity).isEqualTo(toQuantity(balance, decimals)) && (
+              BigNumber(quantity).isEqualTo(toQuantity(balance, decimals)) &&
+              isFeeToken && (
                 <FormHelp level="warning">Make sure to leave enough funds to cover fees</FormHelp>
               )}
 

--- a/packages/widget-react/src/pages/wallet/txs/send/SendFields.tsx
+++ b/packages/widget-react/src/pages/wallet/txs/send/SendFields.tsx
@@ -36,6 +36,8 @@ export const SendFields = () => {
   const balance = balances.find((coin) => coin.denom === denom)?.amount ?? "0"
   const price = prices?.find(({ id }) => id === denom)?.price
 
+  const isMaxAmount =
+    BigNumber(quantity).gt(0) && BigNumber(quantity).isEqualTo(toQuantity(balance, decimals))
   const isFeeToken = chain.fees.fee_tokens.some((token) => token.denom === denom)
 
   const { mutate, isPending } = useMutation({
@@ -93,11 +95,9 @@ export const SendFields = () => {
           </div>
 
           <FormHelp.Stack>
-            {BigNumber(quantity).gt(0) &&
-              BigNumber(quantity).isEqualTo(toQuantity(balance, decimals)) &&
-              isFeeToken && (
-                <FormHelp level="warning">Make sure to leave enough funds to cover fees</FormHelp>
-              )}
+            {isMaxAmount && isFeeToken && (
+              <FormHelp level="warning">Make sure to leave enough funds to cover fees</FormHelp>
+            )}
 
             {!memo && (
               <FormHelp level="warning">Check if the above transaction requires a memo</FormHelp>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved the display of fee-related warnings when sending or bridging assets. Warnings to leave enough funds for fees are now shown only when transferring the full balance of a fee token, reducing unnecessary alerts for non-fee tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->