### PR TITLE
Update connect page design

### DIFF
--- a/packages/widget-react/src/components/List.tsx
+++ b/packages/widget-react/src/components/List.tsx
@@ -11,10 +11,11 @@ interface Props<Item> {
   getKey: (item: Item) => string
   getIsLoading?: (item: Item) => boolean
   getDisabled?: (item: Item) => boolean
+  getExtra?: (item: Item) => React.ReactNode
 }
 
 function List<Item>({ onSelect, list, ...props }: Props<Item>) {
-  const { getImage, getName, getKey, getIsLoading, getDisabled } = props
+  const { getImage, getName, getKey, getIsLoading, getDisabled, getExtra } = props
   return (
     <Scrollable className={styles.scrollable}>
       <div className={styles.list}>
@@ -27,7 +28,7 @@ function List<Item>({ onSelect, list, ...props }: Props<Item>) {
           >
             <Image src={getImage(item)} width={28} height={28} />
             <span className={styles.name}>{getName(item)}</span>
-            {getIsLoading?.(item) && <Loader size={16} />}
+            {getIsLoading?.(item) ? <Loader size={16} /> : getExtra?.(item) || null}
           </button>
         ))}
       </div>

--- a/packages/widget-react/src/data/constants.ts
+++ b/packages/widget-react/src/data/constants.ts
@@ -7,6 +7,7 @@ export const LocalStorageKey = {
 
   // wallet
   PUBLIC_KEY: `${NAMESPACE}:public-key`,
+  RECENT_WALLET: `${NAMESPACE}:recent-wallet`,
 
   // tx fee
   FEE_DENOM: `${NAMESPACE}:fee-denom`,

--- a/packages/widget-react/src/pages/connect/Connect.module.css
+++ b/packages/widget-react/src/pages/connect/Connect.module.css
@@ -1,7 +1,45 @@
-.title {
-  border-bottom: 1px solid var(--border);
-  font-size: 20px;
-  font-weight: 600;
-  padding: 24px;
-  padding-bottom: 20px;
+.container {
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .title {
+    border-bottom: 1px solid var(--border);
+    font-size: 20px;
+    font-weight: 600;
+    padding: 24px;
+    padding-bottom: 20px;
+  }
+
+  .recent {
+    color: var(--info);
+    background-color: var(--info-bg);
+
+    padding: 1px 9px;
+    border-radius: 4px;
+
+    font-size: 11px;
+    line-height: 150%;
+  }
+
+  .footer {
+    padding: 24px;
+    a {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 6px;
+
+      text-decoration: none;
+      color: var(--gray-3);
+      font-size: 14px;
+      font-weight: 600;
+
+      &:hover {
+        color: var(--gray-1);
+      }
+    }
+  }
 }

--- a/packages/widget-react/src/pages/connect/Connect.tsx
+++ b/packages/widget-react/src/pages/connect/Connect.tsx
@@ -2,10 +2,12 @@ import type { Connector } from "wagmi"
 import { useConnect } from "wagmi"
 import { useState } from "react"
 import { useMutation } from "@tanstack/react-query"
+import { IconExternalLink } from "@initia/icons-react"
 import { normalizeError } from "@/data/http"
 import { useWidgetVisibility } from "@/data/ui"
 import List from "@/components/List"
 import styles from "./Connect.module.css"
+import { LocalStorageKey } from "@/data/constants"
 
 const Connect = () => {
   const { closeWidget } = useWidgetVisibility()
@@ -16,6 +18,7 @@ const Connect = () => {
       setPendingConnectorId(connector.id)
       try {
         await connectAsync({ connector })
+        localStorage.setItem(LocalStorageKey.RECENT_WALLET, connector.id)
       } catch (error) {
         throw new Error(await normalizeError(error))
       }
@@ -29,7 +32,7 @@ const Connect = () => {
   })
 
   return (
-    <>
+    <div className={styles.container}>
       <h1 className={styles.title}>Connect wallet</h1>
       <List
         list={[...connectors]}
@@ -39,8 +42,18 @@ const Connect = () => {
         getKey={({ id }) => id}
         getIsLoading={({ id }) => id === pendingConnectorId}
         getDisabled={() => isPending}
+        getExtra={({ id }) =>
+          id === localStorage.getItem(LocalStorageKey.RECENT_WALLET) ? (
+            <span className={styles.recent}>Recent</span>
+          ) : null
+        }
       />
-    </>
+      <footer className={styles.footer}>
+        <a href="https://docs.initia.xyz/home/tools/wallet-widget" target="_blank" rel="noreferrer">
+          Initia Widget guide <IconExternalLink size={14} />
+        </a>
+      </footer>
+    </div>
   )
 }
 


### PR DESCRIPTION
- Show recent wallet [FE-1383](https://linear.app/initia-labs/issue/FE-1383/show-last-connected-wallet)
- Add link to widget guide [FE-1381](https://linear.app/initia-labs/issue/FE-1381/link-to-wallet-guide-in-the-wallet-connection-screen)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displays a "Recent" label next to the most recently connected wallet for easier identification.
  * Added a footer section with a link to the Initia Widget guide, opening in a new tab.

* **Enhancements**
  * Improved list rendering by allowing extra content to be displayed for each item when not loading.

* **Style**
  * Updated layout and styling for the Connect page, including new container, recent, and footer styles for a more organized appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->