### PR TITLE
Handle bigdecimal bcs

### DIFF
--- a/packages/widget-react/src/pages/tx/stringify.test.ts
+++ b/packages/widget-react/src/pages/tx/stringify.test.ts
@@ -56,7 +56,7 @@ describe("resolveBcsType", () => {
   it("parses bigdecimals correctly", () => {
     const parse = (input: string) => resolveBcsType("bigdecimal").parse(fromBase64(input))
 
-    expect(parse("CU7zPBOdY66sBg==")).toBe(Number("123.123456789012345678"))
-    expect(parse("AWQ=")).toBe(Number("0.0000000000000001"))
+    expect(parse("CU7zPBOdY66sBg==")).toBe("123.123456789012345678")
+    expect(parse("AWQ=")).toBe("0.0000000000000001")
   })
 })

--- a/packages/widget-react/src/pages/tx/stringify.test.ts
+++ b/packages/widget-react/src/pages/tx/stringify.test.ts
@@ -52,4 +52,11 @@ describe("resolveBcsType", () => {
     expect(parse("AA==")).toBeNull()
     expect(parse("Af8=")).toBe(255)
   })
+
+  it("parses bigdecimals correctly", () => {
+    const parse = (input: string) => resolveBcsType("bigdecimal").parse(fromBase64(input))
+
+    expect(parse("CU7zPBOdY66sBg==")).toBe(Number("123.123456789012345678"))
+    expect(parse("AWQ=")).toBe(Number("0.0000000000000001"))
+  })
 })

--- a/packages/widget-react/src/pages/tx/stringify.test.ts
+++ b/packages/widget-react/src/pages/tx/stringify.test.ts
@@ -53,10 +53,11 @@ describe("resolveBcsType", () => {
     expect(parse("Af8=")).toBe(255)
   })
 
-  it("parses bigdecimals correctly", () => {
+  it("parses bigdecimal values correctly", () => {
     const parse = (input: string) => resolveBcsType("bigdecimal").parse(fromBase64(input))
 
-    expect(parse("CU7zPBOdY66sBg==")).toBe("123.123456789012345678")
-    expect(parse("AWQ=")).toBe("0.0000000000000001")
+    expect(parse("AQo=")).toBe("0.00000000000000001")
+    expect(parse("AQE=")).toBe("0.000000000000000001")
+    expect(parse("D07zzP6X5NXzf+x01ha8AQ==")).toBe("9007199254740991.123456789012345678")
   })
 })

--- a/packages/widget-react/src/pages/tx/stringify.ts
+++ b/packages/widget-react/src/pages/tx/stringify.ts
@@ -74,7 +74,10 @@ function bigdecimalSerializer(options?: BcsTypeOptions<string, string | number>)
     },
     output: (val) => {
       const biguint = fromLittleEndian(val).toString()
-      return new BigNumber(biguint).div(new BigNumber("1000000000000000000")).toNumber()
+      // since these values will be displayed to the user, avoid exponential notation (e.g. 1e-18)
+      BigNumber.config({ EXPONENTIAL_AT: 1e9 })
+      // convert to string instead of number, otherwise it might loose precision
+      return new BigNumber(biguint).div(new BigNumber("1000000000000000000")).toString()
     },
   })
 }


### PR DESCRIPTION
Related Linear issue: [FE-1391](https://linear.app/initia-labs/issue/FE-1391/add-support-for-bigdecimal-when-extending-bcs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for precise handling of "bigdecimal" types, allowing accurate encoding and decoding of high-precision decimal numbers.
* **Tests**
  * Introduced new test cases to verify correct parsing and string output for "bigdecimal" values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->