### PR TITLE
Add pagination to history and improve tracking requests

### DIFF
--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.module.css
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.module.css
@@ -13,3 +13,18 @@
 .item {
   border-bottom: 1px solid var(--border);
 }
+
+.showMore {
+  color: var(--gray-3);
+  margin: 16px auto;
+  font-size: 12px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+
+  &:hover {
+    color: var(--gray-1);
+  }
+}

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistory.tsx
@@ -1,10 +1,16 @@
+import { useState } from "react"
 import { useToggle } from "react-use"
+import { IconChevronDown } from "@initia/icons-react"
 import { useInterwovenKit } from "@/public/data/hooks"
 import Page from "@/components/Page"
 import Status from "@/components/Status"
 import AsyncBoundary from "@/components/AsyncBoundary"
 import CheckboxButton from "@/components/CheckboxButton"
-import { BRIDGE_HISTORY_LIMIT, useBridgeHistoryList } from "./data/history"
+import {
+  BRIDGE_HISTORY_ITEMS_PER_PAGE,
+  BRIDGE_HISTORY_LIMIT,
+  useBridgeHistoryList,
+} from "./data/history"
 import BridgeHistoryItem from "./BridgeHistoryItem"
 import styles from "./BridgeHistory.module.css"
 
@@ -20,8 +26,10 @@ const BridgeHistory = () => {
     return [sender, recipient].some((address) => [initiaAddress, hexAddress].includes(address))
   })
 
+  const [page, setPage] = useState(1)
   const [showAll, toggleShowAll] = useToggle(!myHistory.length)
   const filteredHistory = showAll ? allHistory : myHistory
+  const paginatedHistory = filteredHistory.slice(0, page * BRIDGE_HISTORY_ITEMS_PER_PAGE)
 
   return (
     <Page title="Bridge/Swap activity">
@@ -40,7 +48,7 @@ const BridgeHistory = () => {
         {filteredHistory.length === 0 ? (
           <Status>No bridge/swap activity</Status>
         ) : (
-          filteredHistory.map((tx, index) => (
+          paginatedHistory.map((tx, index) => (
             <div className={styles.item} key={index}>
               <AsyncBoundary>
                 <BridgeHistoryItem tx={tx} />
@@ -49,11 +57,17 @@ const BridgeHistory = () => {
           ))
         )}
 
-        {history.length >= BRIDGE_HISTORY_LIMIT && (
-          <Status>
-            Only the latest {BRIDGE_HISTORY_LIMIT} items are stored. Older entries will be removed
-            automatically.
-          </Status>
+        {filteredHistory.length > page * BRIDGE_HISTORY_ITEMS_PER_PAGE ? (
+          <button onClick={() => setPage((page) => page + 1)} className={styles.showMore}>
+            Show More <IconChevronDown size={14} />
+          </button>
+        ) : (
+          history.length >= BRIDGE_HISTORY_LIMIT && (
+            <Status>
+              Only the latest {BRIDGE_HISTORY_LIMIT} items are stored. Older entries will be removed
+              automatically.
+            </Status>
+          )
         )}
       </div>
     </Page>

--- a/packages/interwovenkit-react/src/pages/bridge/BridgeHistoryItem.tsx
+++ b/packages/interwovenkit-react/src/pages/bridge/BridgeHistoryItem.tsx
@@ -33,8 +33,8 @@ const BridgeHistoryItem = ({ tx }: { tx: TxIdentifier }) => {
   if (!details) throw new Error("Bridge history details not found")
   const { chainId, txHash, route, values, timestamp } = details
 
-  const { data: trackedTxHash = "" } = useTrackTxQuery(details)
-  const { data: txStatus } = useTxStatusQuery({ ...details, txHash: trackedTxHash })
+  const { data: trackedTxHash = "" } = useTrackTxQuery(details, details.tracked)
+  const { data: txStatus } = useTxStatusQuery(details, !details.tracked || !!details.state)
   const state = details.state ?? getState(txStatus)
 
   const { address: connectedAddress = "", connector } = useAccount()

--- a/packages/interwovenkit-react/src/pages/bridge/data/history.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/history.ts
@@ -21,6 +21,7 @@ const detailKeyOf = ({ chainId, txHash }: TxIdentifier) =>
   `${LocalStorageKey.BRIDGE_HISTORY}:${chainId}:${txHash}`
 
 export const BRIDGE_HISTORY_LIMIT = 100
+export const BRIDGE_HISTORY_ITEMS_PER_PAGE = 10
 
 export function useBridgeHistoryList() {
   const [list = [], setList] = useLocalStorage<TxIdentifier[]>(LocalStorageKey.BRIDGE_HISTORY, [])

--- a/packages/interwovenkit-react/src/pages/bridge/data/tx.ts
+++ b/packages/interwovenkit-react/src/pages/bridge/data/tx.ts
@@ -260,7 +260,7 @@ export function useSignOpHook() {
   })
 }
 
-export function useTrackTxQuery(details: HistoryDetails) {
+export function useTrackTxQuery(details: HistoryDetails, disabled = false) {
   const { chainId, txHash } = details
   const skip = useSkip()
   return useQuery({
@@ -275,13 +275,14 @@ export function useTrackTxQuery(details: HistoryDetails) {
       }
     },
     select: ({ tx_hash }) => tx_hash,
-    retry: 30,
-    retryDelay: 1000,
+    retry: 6,
+    retryDelay: 10_000,
     staleTime: STALE_TIMES.INFINITY,
+    enabled: !disabled,
   })
 }
 
-export function useTxStatusQuery(details: HistoryDetails) {
+export function useTxStatusQuery(details: HistoryDetails, disabled = false) {
   const { timestamp, chainId, txHash, state } = details
   const skip = useSkip()
 
@@ -291,7 +292,7 @@ export function useTxStatusQuery(details: HistoryDetails) {
       skip
         .get("v2/tx/status", { searchParams: { tx_hash: txHash, chain_id: chainId } })
         .json<StatusResponseJson>(),
-    enabled: !!txHash && !state,
+    enabled: !!txHash && !state && !disabled,
     refetchInterval: ({ state: { data } }) => {
       if (!data) return false
       const { status } = data


### PR DESCRIPTION
- Add pagination to bridge history
- Avoid query `v2/tx/status` if tx has already been completed

**Since `v2/tx/track` throws an error if the tx is older than 14 days:**
- Query `v2/tx/track` only if transaction has not already been tracked
- Reduce retries and increase retry interval to prevent spamming the endpoint

